### PR TITLE
一个用于测试api的小工具

### DIFF
--- a/api快速测试/mock_server.py
+++ b/api快速测试/mock_server.py
@@ -1,0 +1,98 @@
+"""
+API模拟测试(支持本地和局域网):
+负责模拟DeepSeek API的标准请求，包括
+- 请求模拟
+- 动态响应
+- 异常测试
+- 延时响应
+"""
+
+from flask import Flask, request, jsonify
+import argparse
+import time
+from threading import Lock
+
+app = Flask(__name__)
+response_lock = Lock()
+
+# 全局配置存储
+config = {
+    "default_response": {"content": "这是默认测试响应"},
+    "enable_test_endpoints": False
+}
+
+@app.route('/v1/chat/completions', methods=['POST'])
+def api_handler():
+    """模拟DeepSeek标准API端点"""
+    with response_lock:
+        current_response = config['default_response'].copy()
+    
+    # 记录请求日志
+    print("\n[请求日志]")
+    print(f"Headers: {dict(request.headers)}")
+    print(f"Body: {request.json}")
+
+    # 构造响应
+    return jsonify({
+        "choices": [{
+            "message": {
+                "content": current_response['content']
+            }
+        }]
+    })
+
+@app.route('/control/set_response', methods=['POST'])
+def set_custom_response():
+    """动态修改响应内容"""
+    if not request.is_json:
+        return jsonify({"error": "需要JSON格式"}), 400
+    
+    new_response = request.json
+    with response_lock:
+        config['default_response'].update(new_response)
+    
+    print(f"\n[配置更新] 新响应内容: {new_response}")
+    return jsonify({"status": "success", "new_response": new_response})
+
+# 以下为测试专用端点（需通过--enable-test启用）
+@app.route('/test/500', methods=['GET', 'POST'])
+def mock_500_error():
+    """模拟服务器错误"""
+    return jsonify({
+        "error": "测试用服务器错误",
+        "detail": "这是模拟的500错误响应"
+    }), 500
+
+@app.route('/test/timeout/<int:delay>', methods=['GET'])
+def mock_timeout(delay):
+    """模拟延时响应"""
+    time.sleep(delay)
+    return jsonify({
+        "status": f"延时 {delay} 秒响应",
+        "data": "请求最终成功"
+    })
+
+if __name__ == '__main__':
+    # 命令行参数配置
+    parser = argparse.ArgumentParser(
+        description='DeepSeek API模拟服务',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument('--port', type=int, default=5000,
+                       help='服务监听端口')
+    parser.add_argument('--enable-test', action='store_true',
+                       help='启用测试端点(/test/*)')
+    args = parser.parse_args()
+
+    # 根据参数配置功能
+    config['enable_test_endpoints'] = args.enable_test
+
+    # 启动提示信息
+    print(f"\n服务启动配置：")
+    print(f"监听端口: {args.port}")
+    print(f"测试端点: {'已启用' if args.enable_test else '已禁用'}")
+    print(f"控制接口: POST /control/set_response")
+    print(f"标准端点: POST /v1/chat/completions")
+    
+    # 启动服务（设置debug=False生产环境）
+    app.run(host='0.0.0.0', port=args.port, debug=False)

--- a/api快速测试/new_api_request.py
+++ b/api快速测试/new_api_request.py
@@ -1,0 +1,84 @@
+import requests
+
+# 服务地址和端口，这里替换为实际的服务器地址
+base_url = 'http://your-server-address:port'
+# 替换为实际的 API 密钥
+api_key = 'your-api-key'
+
+# 1. 向标准 API 端点发送请求
+def test_standard_api():
+    """
+    测试标准 API 端点 /v1/chat/completions
+    """
+    url = f'{base_url}/v1/chat/completions'
+    headers = {
+        'Content-Type': 'application/json',
+        'Authorization': f'Bearer {api_key}'
+    }
+    data = {
+        "prompt": "这是一个测试请求"
+    }
+    response = requests.post(url, headers=headers, json=data)
+    print("标准 API 端点响应:")
+    print(response.json())
+
+# 2. 动态修改响应内容
+def test_set_custom_response():
+    """
+    测试动态修改响应内容的接口 /control/set_response
+    """
+    url = f'{base_url}/control/set_response'
+    headers = {
+        'Content-Type': 'application/json',
+        'Authorization': f'Bearer {api_key}'
+    }
+    new_response = {
+        "content": "这是自定义的测试响应"
+    }
+    response = requests.post(url, headers=headers, json=new_response)
+    print("动态修改响应内容的接口响应:")
+    print(response.json())
+
+# 3. 模拟服务器错误
+def test_mock_500_error():
+    """
+    测试模拟服务器错误的接口 /test/500
+    """
+    url = f'{base_url}/test/500'
+    headers = {
+        'Authorization': f'Bearer {api_key}'
+    }
+    response = requests.get(url, headers=headers)
+    print("模拟服务器错误的接口响应:")
+    print(response.status_code)
+    print(response.json())
+
+# 4. 模拟延时响应
+def test_mock_timeout():
+    """
+    测试模拟延时响应的接口 /test/timeout/<delay>
+    """
+    delay = 5  # 延时 5 秒
+    url = f'{base_url}/test/timeout/{delay}'
+    headers = {
+        'Authorization': f'Bearer {api_key}'
+    }
+    response = requests.get(url, headers=headers)
+    print("模拟延时响应的接口响应:")
+    print(response.json())
+
+if __name__ == "__main__":
+    # 测试标准 API 端点
+    test_standard_api()
+
+    # 动态修改响应内容
+    test_set_custom_response()
+
+    # 再次测试标准 API 端点，验证响应内容是否已修改
+    test_standard_api()
+
+    # 模拟服务器错误
+    test_mock_500_error()
+
+    # 模拟延时响应
+    test_mock_timeout()


### PR DESCRIPTION
mock_serve.py用于在本机地址5000端口上模拟deepseek服务器发送api，具体用法详见注释。
new_api_request.py用于直接请求api，url与key需要自行配置