### PR TITLE
修正 gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ out
 gen
 ### Python template
 # Byte-compiled / optimized / DLL files
-__pycache__/
+/__pycache__/
 *.py[cod]
 *$py.class
 


### PR DESCRIPTION
`pycache` 可能会被包含在子文件夹内. 该提交使 git 也忽略子文件夹的 `__pycache__`.