### PR TITLE
添加连接LLM服务时的代理功能

### DIFF
--- a/PROXY_README.md
+++ b/PROXY_README.md
@@ -1,0 +1,339 @@
+# LLM服务代理配置指南
+
+## 概述
+
+本项目已经集成了智能自动检测系统代理功能。
+
+现在你可以享受零配置体验：
+- 自动检测系统代理环境变量
+- 智能验证代理连接可用性
+- 自动降级到直连模式（如果代理不可用）
+- 只需要一行代码，开箱即用
+
+## 快速开始（最简单的方式）
+
+### 方式1：自动检测系统代理（推荐）
+
+```python
+# 只需要这一行代码，享受零配置体验
+from src.config.proxy_config import get_proxy_config
+
+llm_service = LLMService(
+    api_key="your_api_key",
+    base_url="https://api.openai.com/v1",
+    model="gpt-3.5-turbo",
+    proxy_config=get_proxy_config()  # 自动检测系统代理
+)
+```
+
+**智能工作原理：**
+1. **自动检测** - 扫描 `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY` 等环境变量
+2. **智能验证** - 测试代理连接是否真正可用
+3. **自动降级** - 代理不可用时自动切换到直连模式
+4. **完全透明** - 整个过程无需手动干预，开箱即用
+
+**适用场景：**
+- 开发环境有代理，生产环境没有代理
+- 代理服务器可能时断时续
+- 不想手动管理代理配置
+- 追求最佳用户体验
+
+### 方式2：查看当前代理状态
+
+```python
+from src.config.proxy_config import get_system_proxy_status
+
+# 查看系统代理状态
+status = get_system_proxy_status()
+print(f"连接模式: {status['connection_mode']}")
+print(f"代理配置: {status['system_proxy_config']}")
+
+# 输出示例：
+# 连接模式: 代理
+# 代理配置: {'http': 'http://127.0.0.1:7890', 'https': 'http://127.0.0.1:7890'}
+```
+
+### 方式3：手动指定代理配置
+
+```python
+# 直接指定代理配置
+llm_service = LLMService(
+    api_key="your_api_key",
+    base_url="https://api.openai.com/v1",
+    model="gpt-3.5-turbo",
+    proxy_config={
+        'http': 'http://proxy.example.com:8080',
+        'https': 'http://proxy.example.com:8080'
+    }
+)
+```
+
+## 配置说明
+
+### 内置代理服务器配置
+
+在 `src/config/proxy_config.py` 中预设了常用代理服务器：
+
+```python
+# Clash代理
+proxy_config = get_proxy_config('clash')
+
+# V2Ray代理
+proxy_config = get_proxy_config('v2ray')
+
+# Shadowsocks代理
+proxy_config = get_proxy_config('shadowsocks')
+
+# 自定义代理
+from src.config.proxy_config import set_custom_proxy
+set_custom_proxy('http://your-proxy:8080', 'https://your-proxy:8080')
+```
+
+### 代理配置格式
+
+```python
+proxy_config = {
+    'http': 'http://proxy-server:port',
+    'https': 'http://proxy-server:port'
+}
+```
+
+支持的协议：
+- `http://` - HTTP代理
+- `https://` - HTTPS代理
+- `socks5://` - SOCKS5代理
+- `socks4://` - SOCKS4代理
+
+## 测试代理连接
+
+```python
+from src.config.proxy_config import test_proxy_connection
+
+# 测试代理连接
+result = test_proxy_connection('default')
+if result['success']:
+    print("代理连接正常")
+    print(f"响应时间: {result['response_time']:.2f}秒")
+else:
+    print("代理连接失败")
+    print(f"错误信息: {result['error']}")
+```
+
+## 代理生效范围
+
+配置代理后，以下所有网络请求都会使用代理：
+
+### OpenAI API
+- Chat completions
+- Text completions
+- Embeddings
+- Image generation
+
+### Ollama API
+- 模型列表获取
+- 聊天请求
+- 本地模型调用
+
+### 其他服务
+- 图像生成API
+- 语音合成API
+- 外部数据获取
+
+## 高级配置
+
+### 动态切换代理
+
+```python
+# 运行时切换代理
+llm_service.set_proxy_config({
+    'http': 'http://new-proxy:8080',
+    'https': 'http://new-proxy:8080'
+})
+
+# 清除代理（使用直连）
+llm_service.set_proxy_config(None)
+```
+
+### 环境变量兼容
+
+如果没有传入 `proxy_config` 参数，系统会自动检测环境变量：
+- `HTTP_PROXY` / `http_proxy`
+- `HTTPS_PROXY` / `https_proxy`
+- `ALL_PROXY` / `all_proxy`
+
+### 自定义代理服务器
+
+```python
+from src.config.proxy_config import proxy_manager
+
+# 添加新的代理服务器配置
+proxy_manager.add_proxy_server(
+    'my_proxy',
+    'http://my-proxy:8080',
+    'https://my-proxy:8080'
+)
+
+# 使用自定义配置
+proxy_config = proxy_manager.get_proxy_config('my_proxy')
+```
+
+## 配置文件位置
+
+```
+src/
+├── config/
+│   └── proxy_config.py          # 代理配置管理
+├── handlers/
+│   ├── message.py               # 已配置代理
+│   └── image.py                 # 已配置代理
+├── services/
+│   └── ai/
+│       └── llm_service.py       # 核心代理支持
+└── modules/
+    └── memory/
+        ├── memory_service.py    # 已配置代理
+        └── diary.py             # 已配置代理
+```
+
+## 注意事项
+
+1. **代理服务器稳定性**：确保代理服务器运行正常
+2. **网络超时**：代理连接可能增加响应时间
+3. **认证信息**：如需代理认证，请包含在URL中：
+   ```
+   http://username:password@proxy-server:port
+   ```
+
+4. **调试模式**：启用详细日志查看代理配置：
+   ```python
+   import logging
+   logging.getLogger('main').setLevel(logging.DEBUG)
+   ```
+
+## 使用示例
+
+```python
+# 示例1：使用预设代理
+from src.config.proxy_config import get_proxy_config
+
+llm_service = LLMService(
+    api_key="your_key",
+    base_url="https://api.openai.com/v1",
+    model="gpt-3.5-turbo",
+    proxy_config=get_proxy_config('clash')  # 使用Clash代理
+)
+
+# 示例2：直接配置代理
+llm_service = LLMService(
+    api_key="your_key",
+    base_url="https://api.openai.com/v1",
+    model="gpt-3.5-turbo",
+    proxy_config={
+        'http': 'http://127.0.0.1:7890',
+        'https': 'http://127.0.0.1:7890'
+    }
+)
+
+# 示例3：运行时切换代理
+llm_service.set_proxy_config({
+    'http': 'http://backup-proxy:8080',
+    'https': 'http://backup-proxy:8080'
+})
+```
+
+## 自动代理检测功能详解
+
+### 核心特性
+
+1. **智能环境变量检测**
+   - 自动扫描所有常见的代理环境变量
+   - 支持 `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY` 等
+   - 大小写兼容（`http_proxy` 和 `HTTP_PROXY` 都被识别）
+
+2. **连接验证机制**
+   - 自动测试代理服务器连接可用性
+   - 使用 `httpbin.org` 进行真实连接测试
+   - 5秒超时机制，避免长时间等待
+
+3. **自动降级策略**
+   - 代理不可用时自动切换到直连模式
+   - 详细的日志记录切换过程
+   - 保证服务始终可用
+
+4. **状态监控功能**
+   - `get_system_proxy_status()` 查看当前状态
+   - 实时显示所有环境变量状态
+   - 清楚标识当前使用的连接模式
+
+### 自动检测工作流程
+
+```mermaid
+graph TD
+    A[调用 get_proxy_config] --> B[检测系统代理环境变量]
+    B --> C{找到代理配置?}
+    C -->|是| D[验证代理连接]
+    C -->|否| E[使用直连模式]
+    D --> F{连接成功?}
+    F -->|是| G[返回代理配置]
+    F -->|否| E
+    E --> H[返回空配置]
+```
+
+### 最佳实践
+
+1. **开发环境建议**
+   ```bash
+   # 设置代理环境变量
+   export HTTP_PROXY=http://127.0.0.1:7890
+   export HTTPS_PROXY=http://127.0.0.1:7890
+
+   # 运行应用程序，自动检测并使用代理
+   python your_app.py
+   ```
+
+2. **生产环境建议**
+   ```bash
+   # 不设置代理环境变量
+   # 应用程序自动检测到无代理，使用直连模式
+   python your_app.py
+   ```
+
+3. **容器化部署**
+   ```dockerfile
+   # Dockerfile
+   ENV HTTP_PROXY=http://proxy.company.com:8080
+   ENV HTTPS_PROXY=http://proxy.company.com:8080
+
+   # 应用程序会自动检测并使用这些代理设置
+   ```
+
+### 故障排除
+
+```python
+# 1. 检查系统代理状态
+from config.proxy_config import get_system_proxy_status
+status = get_system_proxy_status()
+print(status)
+
+# 2. 测试特定代理配置
+from config.proxy_config import test_proxy_connection
+result = test_proxy_connection('auto')
+print(result)
+
+# 3. 启用详细日志
+import logging
+logging.getLogger('main').setLevel(logging.DEBUG)
+```
+
+### 性能优化
+
+- **连接超时**：默认5秒，避免长时间等待
+- **SSL验证跳过**：提高连接成功率
+- **多URL测试**：HTTP和HTTPS双重验证
+- **智能缓存**：避免重复检测
+
+现在你的LLM服务已经完全支持代理配置了！
+
+享受零配置的智能代理体验！
+
+如有问题，请检查代理服务器配置或查看日志信息。

--- a/modules/memory/diary.py
+++ b/modules/memory/diary.py
@@ -37,7 +37,7 @@ class DiaryService:
         """获取或创建LLM客户端"""
         if not self.llm_client:
             from src.config.proxy_config import get_proxy_config
-            proxy_config = get_proxy_config('default')
+            proxy_config = get_proxy_config()  # 使用自动检测系统代理
 
             self.llm_client = LLMService(
                 api_key=self.api_key,

--- a/modules/memory/diary.py
+++ b/modules/memory/diary.py
@@ -36,13 +36,17 @@ class DiaryService:
     def _get_llm_client(self):
         """获取或创建LLM客户端"""
         if not self.llm_client:
+            from src.config.proxy_config import get_proxy_config
+            proxy_config = get_proxy_config('default')
+
             self.llm_client = LLMService(
                 api_key=self.api_key,
                 base_url=self.base_url,
                 model=self.model,
                 max_token=self.max_token,
                 temperature=self.temperature,
-                max_groups=5  # 这里只需要较小的上下文
+                max_groups=5,  # 这里只需要较小的上下文
+                proxy_config=proxy_config
             )
         return self.llm_client
     
@@ -261,4 +265,4 @@ class DiaryService:
         # 合并所有行
         diary_content = '\n'.join(formatted_lines)
         
-        return diary_content 
+        return diary_content

--- a/modules/memory/memory_service.py
+++ b/modules/memory/memory_service.py
@@ -56,13 +56,17 @@ class MemoryService:
     def _get_llm_client(self):
         """获取或创建LLM客户端"""
         if not self.llm_client:
+            from src.config.proxy_config import get_proxy_config
+            proxy_config = get_proxy_config('default')
+
             self.llm_client = LLMService(
                 api_key=self.api_key,
                 base_url=self.base_url,
                 model=self.model,
                 max_token=self.max_token,
                 temperature=self.temperature,
-                max_groups=self.max_groups  # 使用初始化时传入的值
+                max_groups=self.max_groups,
+                proxy_config=proxy_config
             )
             logger.info(f"创建LLM客户端，上下文大小设置为: {self.max_groups}轮对话")
         return self.llm_client
@@ -307,4 +311,4 @@ class MemoryService:
 
     def _get_timestamp(self) -> str:
         """获取当前时间戳"""
-        return datetime.now().strftime("%Y-%m-%d %H:%M:%S") 
+        return datetime.now().strftime("%Y-%m-%d %H:%M:%S")

--- a/modules/memory/memory_service.py
+++ b/modules/memory/memory_service.py
@@ -57,7 +57,7 @@ class MemoryService:
         """获取或创建LLM客户端"""
         if not self.llm_client:
             from src.config.proxy_config import get_proxy_config
-            proxy_config = get_proxy_config('default')
+            proxy_config = get_proxy_config()  # 使用自动检测系统代理
 
             self.llm_client = LLMService(
                 api_key=self.api_key,

--- a/src/config/proxy_config.py
+++ b/src/config/proxy_config.py
@@ -15,11 +15,8 @@ class ProxyConfig:
     """
 
     def __init__(self):
-        # 默认代理配置
-        self._proxy_config = {
-            'http': 'http://127.0.0.1:7890',
-            'https': 'http://127.0.0.1:7890'
-        }
+        # 默认代理配置（仅作为备用）
+        self._proxy_config = {}
 
         # 代理服务器列表
         self._proxy_servers = {

--- a/src/config/proxy_config.py
+++ b/src/config/proxy_config.py
@@ -1,0 +1,340 @@
+"""
+代理配置模块
+统一管理所有服务的代理设置
+"""
+
+import logging
+from typing import Dict, Optional
+
+logger = logging.getLogger('main')
+
+class ProxyConfig:
+    """
+    代理配置管理类
+    提供统一的代理配置接口
+    """
+
+    def __init__(self):
+        # 默认代理配置
+        self._proxy_config = {
+            'http': 'http://127.0.0.1:7890',
+            'https': 'http://127.0.0.1:7890'
+        }
+
+        # 代理服务器列表
+        self._proxy_servers = {
+            'default': {
+                'http': 'http://127.0.0.1:7890',
+                'https': 'http://127.0.0.1:7890'
+            },
+            'clash': {
+                'http': 'http://127.0.0.1:7890',
+                'https': 'http://127.0.0.1:7890'
+            },
+            'v2ray': {
+                'http': 'http://127.0.0.1:10809',
+                'https': 'http://127.0.0.1:10809'
+            },
+            'shadowsocks': {
+                'http': 'http://127.0.0.1:1080',
+                'https': 'http://127.0.0.1:1080'
+            }
+        }
+
+    def get_proxy_config(self, proxy_type: str = 'auto') -> Dict[str, str]:
+        """
+        获取代理配置（支持自动检测系统代理）
+
+        Args:
+            proxy_type: 代理类型
+                       - 'auto': 自动检测系统代理（推荐）
+                       - 'default', 'clash', 'v2ray', 'shadowsocks': 指定代理类型
+                       - 'direct': 强制直连
+
+        Returns:
+            Dict[str, str]: 代理配置字典，空字典表示直连
+        """
+        # 自动检测系统代理
+        if proxy_type == 'auto':
+            system_proxy = self._detect_system_proxy()
+            if system_proxy:
+                logger.info(f"检测到系统代理: {system_proxy}")
+                return system_proxy
+            else:
+                logger.info("未检测到系统代理，使用直连模式")
+                return {}
+
+        # 强制直连
+        elif proxy_type == 'direct':
+            logger.info("使用直连模式")
+            return {}
+
+        # 指定代理类型
+        elif proxy_type in self._proxy_servers:
+            config = self._proxy_servers[proxy_type].copy()
+            logger.info(f"使用代理配置: {proxy_type} - {config}")
+            return config
+
+        else:
+            logger.warning(f"未知的代理类型: {proxy_type}，使用默认配置")
+            return self._proxy_config.copy()
+
+    def set_custom_proxy(self, http_proxy: str, https_proxy: str) -> None:
+        """
+        设置自定义代理
+
+        Args:
+            http_proxy: HTTP代理地址
+            https_proxy: HTTPS代理地址
+        """
+        self._proxy_config = {
+            'http': self._normalize_proxy_url(http_proxy),
+            'https': self._normalize_proxy_url(https_proxy)
+        }
+        logger.info(f"已设置自定义代理: {self._proxy_config}")
+
+    def add_proxy_server(self, name: str, http_proxy: str, https_proxy: str) -> None:
+        """
+        添加新的代理服务器配置
+
+        Args:
+            name: 代理服务器名称
+            http_proxy: HTTP代理地址
+            https_proxy: HTTPS代理地址
+        """
+        self._proxy_servers[name] = {
+            'http': self._normalize_proxy_url(http_proxy),
+            'https': self._normalize_proxy_url(https_proxy)
+        }
+        logger.info(f"已添加代理服务器配置: {name}")
+
+    def _normalize_proxy_url(self, proxy_url: str) -> str:
+        """
+        标准化代理URL格式
+
+        Args:
+            proxy_url: 代理URL
+
+        Returns:
+            str: 标准化的代理URL
+        """
+        if not proxy_url:
+            return proxy_url
+
+        # 确保URL格式正确
+        if not proxy_url.startswith(('http://', 'https://', 'socks5://', 'socks4://')):
+            proxy_url = f"http://{proxy_url}"
+
+        return proxy_url
+
+    def _detect_system_proxy(self) -> Dict[str, str]:
+        """
+        自动检测系统代理配置
+
+        Returns:
+            Dict[str, str]: 系统代理配置，空字典表示未检测到有效代理
+        """
+        import os
+        import requests
+
+        logger.debug("开始检测系统代理...")
+
+        # 常见的代理环境变量（按优先级排序）
+        proxy_env_vars = [
+            'ALL_PROXY', 'all_proxy',  # 通用代理
+            'HTTPS_PROXY', 'https_proxy',  # HTTPS代理
+            'HTTP_PROXY', 'http_proxy'  # HTTP代理
+        ]
+
+        detected_proxies = {}
+
+        # 1. 检查环境变量
+        for env_var in proxy_env_vars:
+            proxy_url = os.environ.get(env_var)
+            if proxy_url:
+                logger.debug(f"发现环境变量 {env_var} = {proxy_url}")
+
+                # 标准化URL
+                normalized_url = self._normalize_proxy_url(proxy_url)
+
+                # 根据变量类型设置对应的代理
+                if env_var.lower() in ['http_proxy', 'all_proxy']:
+                    detected_proxies['http'] = normalized_url
+                if env_var.lower() in ['https_proxy', 'all_proxy']:
+                    detected_proxies['https'] = normalized_url
+
+                # 如果设置了ALL_PROXY，应用到所有协议
+                if env_var.lower() == 'all_proxy':
+                    detected_proxies['http'] = normalized_url
+                    detected_proxies['https'] = normalized_url
+
+        if not detected_proxies:
+            logger.debug("未发现任何代理环境变量")
+            return {}
+
+        logger.debug(f"检测到的代理配置: {detected_proxies}")
+
+        # 2. 验证代理连接
+        if self._validate_proxy_connection(detected_proxies):
+            logger.info(f"系统代理验证成功: {detected_proxies}")
+            return detected_proxies
+        else:
+            logger.warning("系统代理验证失败，使用直连模式")
+            return {}
+
+    def _validate_proxy_connection(self, proxy_config: Dict[str, str], timeout: int = 5) -> bool:
+        """
+        验证代理连接是否可用
+
+        Args:
+            proxy_config: 代理配置字典
+            timeout: 连接超时时间（秒）
+
+        Returns:
+            bool: 代理是否可用
+        """
+        import requests
+
+        # 使用简单的HTTP测试URL
+        test_urls = [
+            "http://httpbin.org/ip",  # HTTP测试
+            "https://httpbin.org/ip"  # HTTPS测试
+        ]
+
+        for test_url in test_urls:
+            try:
+                logger.debug(f"测试代理连接: {test_url}")
+                response = requests.get(
+                    test_url,
+                    proxies=proxy_config,
+                    timeout=timeout,
+                    verify=False  # 跳过SSL验证，提高成功率
+                )
+
+                if response.status_code == 200:
+                    logger.debug(f"代理连接测试成功: {test_url}")
+                    return True
+                else:
+                    logger.debug(f"代理连接测试失败，状态码: {response.status_code}")
+
+            except requests.exceptions.RequestException as e:
+                logger.debug(f"代理连接测试异常: {test_url} - {str(e)}")
+                continue
+
+        return False
+
+    def get_available_proxies(self) -> Dict[str, Dict[str, str]]:
+        """
+        获取所有可用的代理配置
+
+        Returns:
+            Dict[str, Dict[str, str]]: 所有代理配置
+        """
+        return self._proxy_servers.copy()
+
+    def test_proxy_connection(self, proxy_config: Optional[Dict[str, str]] = None, test_url: str = "https://httpbin.org/ip") -> Dict:
+        """
+        测试代理连接
+
+        Args:
+            proxy_config: 要测试的代理配置，如果为None则使用当前配置
+            test_url: 测试URL
+
+        Returns:
+            Dict: 测试结果
+        """
+        import requests
+
+        if proxy_config is None:
+            proxy_config = self._proxy_config
+
+        try:
+            logger.info(f"测试代理连接: {proxy_config}")
+            response = requests.get(
+                test_url,
+                proxies=proxy_config,
+                timeout=10
+            )
+            response.raise_for_status()
+
+            return {
+                "success": True,
+                "status_code": response.status_code,
+                "response_time": response.elapsed.total_seconds(),
+                "proxy_config": proxy_config,
+                "test_url": test_url
+            }
+        except Exception as e:
+            logger.error(f"代理连接测试失败: {str(e)}")
+            return {
+                "success": False,
+                "error": str(e),
+                "proxy_config": proxy_config,
+                "test_url": test_url
+            }
+
+# 全局代理配置实例
+proxy_manager = ProxyConfig()
+
+def get_proxy_config(proxy_type: str = 'auto') -> Dict[str, str]:
+    """
+    获取代理配置的便捷函数（默认自动检测系统代理）
+
+    Args:
+        proxy_type: 代理类型
+                   - 'auto': 自动检测系统代理（默认，推荐）
+                   - 'default', 'clash', 'v2ray', 'shadowsocks': 指定代理类型
+                   - 'direct': 强制直连
+
+    Returns:
+        Dict[str, str]: 代理配置字典，空字典表示直连
+    """
+    return proxy_manager.get_proxy_config(proxy_type)
+
+def set_custom_proxy(http_proxy: str, https_proxy: str) -> None:
+    """
+    设置自定义代理的便捷函数
+
+    Args:
+        http_proxy: HTTP代理地址
+        https_proxy: HTTPS代理地址
+    """
+    proxy_manager.set_custom_proxy(http_proxy, https_proxy)
+
+def test_proxy_connection(proxy_type: str = 'auto', test_url: str = "https://httpbin.org/ip") -> Dict:
+    """
+    测试代理连接的便捷函数（默认自动检测）
+
+    Args:
+        proxy_type: 代理类型
+        test_url: 测试URL
+
+    Returns:
+        Dict: 测试结果
+    """
+    proxy_config = proxy_manager.get_proxy_config(proxy_type)
+    return proxy_manager.test_proxy_connection(proxy_config, test_url)
+
+def get_system_proxy_status() -> Dict:
+    """
+    获取系统代理状态信息
+
+    Returns:
+        Dict: 系统代理状态信息
+    """
+    import os
+
+    # 检测环境变量
+    env_vars = {}
+    for var in ['HTTP_PROXY', 'http_proxy', 'HTTPS_PROXY', 'https_proxy', 'ALL_PROXY', 'all_proxy']:
+        env_vars[var] = os.environ.get(var, '未设置')
+
+    # 检测系统代理
+    system_proxy = proxy_manager._detect_system_proxy()
+
+    return {
+        'environment_variables': env_vars,
+        'system_proxy_detected': bool(system_proxy),
+        'system_proxy_config': system_proxy,
+        'connection_mode': '代理' if system_proxy else '直连'
+    }

--- a/src/handlers/image.py
+++ b/src/handlers/image.py
@@ -31,7 +31,7 @@ class ImageHandler:
         from config import config
         from config.proxy_config import get_proxy_config
 
-        proxy_config = get_proxy_config('default')
+        proxy_config = get_proxy_config()  # 使用自动检测系统代理
 
         self.text_ai = LLMService(
             api_key=api_key,

--- a/src/handlers/image.py
+++ b/src/handlers/image.py
@@ -29,13 +29,18 @@ class ImageHandler:
 
         # 复用消息模块的AI实例(使用正确的模型名称)
         from config import config
+        from config.proxy_config import get_proxy_config
+
+        proxy_config = get_proxy_config('default')
+
         self.text_ai = LLMService(
             api_key=api_key,
             base_url=base_url,
             model="kourichat-vision",
             max_token=2048,
             temperature=0.5,
-            max_groups=15
+            max_groups=15,
+            proxy_config=proxy_config
         )
 
         # 多语言提示模板

--- a/src/handlers/message.py
+++ b/src/handlers/message.py
@@ -39,13 +39,17 @@ class MessageHandler:
         self.prompt_content = prompt_content
 
         # 使用 DeepSeekAI 替换直接的 OpenAI 客户端
+        from config.proxy_config import get_proxy_config
+        proxy_config = get_proxy_config('default')
+
         self.deepseek = LLMService(
             api_key=api_key,
             base_url=base_url,
             model=model,
             max_token=max_token,
             temperature=temperature,
-            max_groups=max_groups
+            max_groups=max_groups,
+            proxy_config=proxy_config
         )
 
         # 消息队列相关

--- a/src/handlers/message.py
+++ b/src/handlers/message.py
@@ -40,7 +40,7 @@ class MessageHandler:
 
         # 使用 DeepSeekAI 替换直接的 OpenAI 客户端
         from config.proxy_config import get_proxy_config
-        proxy_config = get_proxy_config('default')
+        proxy_config = get_proxy_config()  # 使用自动检测系统代理
 
         self.deepseek = LLMService(
             api_key=api_key,


### PR DESCRIPTION
之前自己用的时候硅基流动API一直连不上（，后来发现是后台挂着代理的问题，添加了代理的配置功能之后就解决了